### PR TITLE
alter normalization

### DIFF
--- a/constraints/digest_constraints3.pro
+++ b/constraints/digest_constraints3.pro
@@ -26,7 +26,7 @@ pro digest_constraints3,files,angles,coords,lengths,weights, $
 ;;                                                            ;;
 ;; Outputs: angles - the measured POS B field angles          ;;
 ;;          coords - 3xn array of coordinates where angles    ;;
-;;            were measured (longitude,latitude,radius) in    ;;
+;;            were measured (longitude,co-latitude,radius) in    ;;
 ;;            units of (radians,radians,solar radii)          ;;
 ;;          spcCoords - 2xn array giving the latitude,       ;;
 ;;            longitude from which the constraint angles are to;;

--- a/constraints/digest_constraints3.pro
+++ b/constraints/digest_constraints3.pro
@@ -1,6 +1,10 @@
 pro digest_constraints3,files,angles,coords,lengths,weights, $
                spcCoords, nfeatures, obs_times, img_enhs, $
-               hdrs
+               hdrs, badfiles=badfiles
+
+;;;;;; Note: I should add another output, nconstraints, to 
+;;;;;    preserve the number of constraints associated with
+;;;;;    each feature
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                            ;;
@@ -19,10 +23,6 @@ pro digest_constraints3,files,angles,coords,lengths,weights, $
 ;;                 detected in the image                      ;;
 ;;               img_enh - coronagraph images with edges      ;;
 ;;                 enhanced using azimuthal derivative        ;;
-;;               header - header from original fits file      ;;
-;;                 sometimes this is a string array, and      ;;
-;;                 sometimes a structure, depending on the    ;;
-;;                 original data source                       ;;
 ;;                                                            ;;
 ;; Outputs: angles - the measured POS B field angles          ;;
 ;;          coords - 3xn array of coordinates where angles    ;;
@@ -56,6 +56,7 @@ angles = []
 lengths = []
 spccoords = fltarr(2,2)  ; need these to be 2D from the beginning
 coords = fltarr(3,2)
+badfiles=[]
 
 ; read files, populate data arrays
 for i=0,nfiles-1 do begin
@@ -71,6 +72,13 @@ for i=0,nfiles-1 do begin
   endif else hdrs = [hdrs, header]
   img_enhs[i,*,*]=img_enh
   wcshead=FITSHEAD2WCS(header)
+  ; check to see if QRaFT has resized the images but not modified the header
+  if wcshead.naxis[0] eq 1024 and szimg_enh[1] eq 512 then begin
+	  fudgefactor = 2
+  endif else if wcshead.naxis[0] ne szimg_enh[1] then begin
+	  print,"header and enhanced image sizes don't agree"
+	  continue
+  endif else fudgefactor = 1
   obs_times[i] = wcshead.time.observ_date
   crlnobs=wcshead.position.crln_obs*!dtor
   ctr=wcshead.crpix
@@ -81,13 +89,32 @@ for i=0,nfiles-1 do begin
     nanglesj = features[j].n_nodes-1
     lengths = [lengths, features[j].l]
     angles = [angles, features[j].angles_p[0:nanglesj-1]]
-    xs = [xs, features[j].angles_xx_r[0:nanglesj-1]]
-    ys = [ys, features[j].angles_yy_r[0:nanglesj-1]]
+    xs = [xs, fudgefactor*features[j].angles_xx_r[0:nanglesj-1]]
+    ys = [ys, fudgefactor*features[j].angles_yy_r[0:nanglesj-1]]
     crlts=REPLICATE(wcshead.position.crlt_obs,nanglesj)
     crlns=REPLICATE(wcshead.position.crln_obs,nanglesj)
     spccoords=[[spccoords], [TRANSPOSE([[crlts],[crlns]])]]
   endfor
+  newcoords = calc_realworld_coords(xs, ys, wcshead)
   coords = [[coords], [calc_realworld_coords(xs, ys, wcshead)]]
+  if min(newcoords[2,*]) lt 1.4 then begin    ; some feature has a bad coordinate value
+	  badfiles = [badfiles, files[i]]
+	  print,'Radial value for one of the constraints is too small.'
+	  print,'filename: '+ files[i]
+	  ; find out why the radial coordinate is so bad
+	  for j=0, n_elements(features.n_nodes)-1 do begin  ; check each feature in the image
+                  nanglesj = features[j].n_nodes-1
+		  thisx = fudgefactor*features[j].angles_xx_r[0:nanglesj-1]
+		  thisy = fudgefactor*features[j].angles_yy_r[0:nanglesj-1]
+                  thiscoords = calc_realworld_coords(thisx, thisy, wcshead)
+	          badlist = where(thiscoords[2,*] lt 1.5,badcount)
+		  if badcount ne 0 then begin   ; if this feature has a bad coordinate value
+	            print,'xs: ',thisx[badlist]
+	            print,'ys: ',thisy[badlist]
+	            print,'r: ',thiscoords[2,badlist]
+		  endif
+	  endfor
+  endif
 
 endfor   ; loop over image files
 

--- a/constraints/draw_constraint_figures.pro
+++ b/constraints/draw_constraint_figures.pro
@@ -23,7 +23,7 @@ pro draw_constraint_figures, files, outfile_stem
 ; loop over image files
 for fnum=0,n_elements(files)-1 do begin
   restore, files[fnum]
-  imgObj=IMAGE(img_enh, /buffer)
+  imgObj=IMAGE(sqrt(img_orig), /buffer)
   ; loop over features
   xs = []
   ys = []

--- a/harmonic_amoeba2.pro
+++ b/harmonic_amoeba2.pro
@@ -211,6 +211,7 @@ function harmonic_amoeba2,magfile,angles,coords,ftol,scale, $
   endif else begin
     magt=SPHERICAL_TRANSFORM(magnetogram,cth,lmax=lmax)
   endelse
+  mag0 = INV_SPHERICAL_TRANSFORM(magt, cth, lmax=lmax)  ; used for magchangepenalty
   if maxlvar gt 1 then begin
     sim0=FORM_INITIAL_VERTEX(magt,maxlvar)
     nvert=N_ELEMENTS(sim0)

--- a/harmonic_amoeba2.pro
+++ b/harmonic_amoeba2.pro
@@ -246,6 +246,7 @@ function harmonic_amoeba2,magfile,angles,coords,ftol,scale, $
     if netfluxpenalty eq 1 then begin
       y=FLTARR(nvert+1)
       psum=TOTAL(simplex,2)
+      penalize_netflux=0.
       obj_fcn=HARMONIC_TRYPOINT2(simplex,y,psum,0,1., $
            angles,coords,spcCoords,/penalty_only)
       penalize_netflux=20.*obj_fcn

--- a/harmonic_trypoint2.pro
+++ b/harmonic_trypoint2.pro
@@ -154,20 +154,21 @@ function harmonic_trypoint2,simplex,y,psum,windex,fac, $
   
   
   ; add optional penalty terms for net flux or magnetogram changes
+  ;    convoluted logic saves double computation of omag - better way?
   if penalize_netflux ne 0. then begin
     if KEYWORD_SET(omag) then oldmag=omag else oldmag= $
       INV_SPHERICAL_TRANSFORM_SJ(magt,cth,lmax=lmax)
     newmag=OPTIMIZATION_INV_TRANSFORM(newmagt,nrix,0,lmax=lmax)
     penalty=penalty+penalize_netflux*MEAN(newmag)^2.
     if penalize_magchange ne 0. then penalty=penalty+ $
-        penalize_magchange*TOTAL(magweights*ABS(newmag-mag0))
+        penalize_magchange*TOTAL(magweights*ABS(newmag-mag0))/(3.*nlat)
 
   endif else if penalize_magchange ne 0. then begin
     if KEYWORD_SET(omag) then oldmag=omag else oldmag= $
          INV_SPHERICAL_TRANSFORM_SJ(magt,cth,lmax=lmax)
     penalty=penalty+penalize_magchange*TOTAL(magweights* $
          ABS(oldmag-OPTIMIZATION_INV_TRANSFORM(newmagt,nrix, $
-         0,lmax=lmax)))
+         0,lmax=lmax)))/(3.*nlat)
   endif
   
   

--- a/harmonic_trypoint2.pro
+++ b/harmonic_trypoint2.pro
@@ -139,7 +139,8 @@ function harmonic_trypoint2,simplex,y,psum,windex,fac, $
   list=WHERE(diffs ge !dpi/2.,cnt)
   if cnt ne 0 then diffs[list]=ABS(diffs[list]-!dpi)
   diffs=diffs^diff_power
-  normal=nconstraints*MEDIAN(weights)*(berr*MEDIAN(angles))^diff_power
+;  normal=nconstraints*MEDIAN(weights)*(berr*MEDIAN(angles))^diff_power
+  normal=nconstraints*MEDIAN(weights)*(!dpi/4.)^diff_power
   penalty=TOTAL(weights*diffs)/normal
 
 

--- a/pfss_opt_parameters.pro
+++ b/pfss_opt_parameters.pro
@@ -1,4 +1,4 @@
 ; common data block for use with phase_varying_amoeba2
 common pfss_opt_parameters,rss,rgrid,magtype,nlat0,berr,pen_mult, $
   cth,magt,lmax,larr,marr,penalize_netflux,imageY,imageZ,noreset, $
-  magnetogram,maxlvar, mag0
+  magnetogram,maxlvar,mag0

--- a/pfss_opt_parameters.pro
+++ b/pfss_opt_parameters.pro
@@ -1,4 +1,4 @@
 ; common data block for use with phase_varying_amoeba2
 common pfss_opt_parameters,rss,rgrid,magtype,nlat0,berr,pen_mult, $
   cth,magt,lmax,larr,marr,penalize_netflux,imageY,imageZ,noreset, $
-  magnetogram,maxlvar
+  magnetogram,maxlvar, mag0


### PR DESCRIPTION
Several changes based on experience working with 2007 & 2008 COR1 data.

1. Previously the objective function used by the optimization software was normalized using a coefficient based on the median angle value.  The new QRaFT output with variable number of nodes per feature caused this value to fluctuate a lot and made it more obvious that this was a wack-a-doo approach.  Basing it instead on the value one would expect from random chance, pi/4.
2. Small bugfixes related to the net flux and magnetogram change penalties, discovered while using those for the first time in a while.
3. Change constraint digestion routine to accommodate the fact that QRaFT doesn't update the image headers when using binned images.  The change is specific to 1024^2 images that have been binned to 512^2 - it's a temporary fix until hopefully QRaFT is updated.